### PR TITLE
fix(idempotency): static pk is overwritten by hashed_idempotency_key

### DIFF
--- a/aws_lambda_powertools/utilities/idempotency/persistence/dynamodb.py
+++ b/aws_lambda_powertools/utilities/idempotency/persistence/dynamodb.py
@@ -146,7 +146,6 @@ class DynamoDBPersistenceLayer(BasePersistenceLayer):
     def _put_record(self, data_record: DataRecord) -> None:
         item = {
             **self._get_key(data_record.idempotency_key),
-            self.key_attr: {"S": data_record.idempotency_key},
             self.expiry_attr: {"N": str(data_record.expiry_timestamp)},
             self.status_attr: {"S": data_record.status},
         }

--- a/tests/functional/idempotency/conftest.py
+++ b/tests/functional/idempotency/conftest.py
@@ -77,7 +77,7 @@ def default_jmespath():
 
 
 @pytest.fixture
-def expected_params_update_item(serialized_lambda_response, hashed_idempotency_keyx):
+def expected_params_update_item(serialized_lambda_response, hashed_idempotency_key):
     return {
         "ExpressionAttributeNames": {
             "#expiry": "expiration",

--- a/tests/functional/idempotency/conftest.py
+++ b/tests/functional/idempotency/conftest.py
@@ -97,22 +97,11 @@ def expected_params_update_item(serialized_lambda_response, hashed_idempotency_k
 
 @pytest.fixture
 def expected_params_update_item_compound_key_static_pk_value(
-    serialized_lambda_response, hashed_idempotency_key, static_pk_value
+    expected_params_update_item, hashed_idempotency_key, static_pk_value
 ):
     return {
-        "ExpressionAttributeNames": {
-            "#expiry": "expiration",
-            "#response_data": "data",
-            "#status": "status",
-        },
-        "ExpressionAttributeValues": {
-            ":expiry": {"N": stub.ANY},
-            ":response_data": {"S": serialized_lambda_response},
-            ":status": {"S": "COMPLETED"},
-        },
+        **expected_params_update_item,
         "Key": {"id": {"S": static_pk_value}, "sk": {"S": hashed_idempotency_key}},
-        "TableName": "TEST_TABLE",
-        "UpdateExpression": "SET #response_data = :response_data, " "#expiry = :expiry, #status = :status",
     }
 
 
@@ -172,23 +161,11 @@ def expected_params_put_item(hashed_idempotency_key):
 
 
 @pytest.fixture
-def expected_params_put_item_compound_key_static_pk_value(hashed_idempotency_key, static_pk_value):
+def expected_params_put_item_compound_key_static_pk_value(
+    expected_params_put_item, hashed_idempotency_key, static_pk_value
+):
     return {
-        "ConditionExpression": (
-            "attribute_not_exists(#id) OR #expiry < :now OR "
-            "(#status = :inprogress AND attribute_exists(#in_progress_expiry) AND #in_progress_expiry < :now_in_millis)"
-        ),
-        "ExpressionAttributeNames": {
-            "#id": "id",
-            "#expiry": "expiration",
-            "#status": "status",
-            "#in_progress_expiry": "in_progress_expiration",
-        },
-        "ExpressionAttributeValues": {
-            ":now": {"N": stub.ANY},
-            ":now_in_millis": {"N": stub.ANY},
-            ":inprogress": {"S": "INPROGRESS"},
-        },
+        **expected_params_put_item,
         "Item": {
             "expiration": {"N": stub.ANY},
             "in_progress_expiration": {"N": stub.ANY},
@@ -196,7 +173,6 @@ def expected_params_put_item_compound_key_static_pk_value(hashed_idempotency_key
             "sk": {"S": hashed_idempotency_key},
             "status": {"S": "INPROGRESS"},
         },
-        "TableName": "TEST_TABLE",
     }
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->
**Issue number:** #1968

## Summary

### Changes

> Fix bug in idempotency DynamoDB Persisence where Static PK Value is overwritten.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-python/blob/develop/.github/semantic.yml)

<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
